### PR TITLE
meson: force static dependencies in portable mode

### DIFF
--- a/freesprite/meson.build
+++ b/freesprite/meson.build
@@ -14,19 +14,19 @@ voidsprite_sources = c.stdout().strip().split('\n')
 thread_dep = dependency('threads')
 
 # We use WrapDB wraps for these dependencies (see subprojects/*.wrap in root):
-libpng_dep = dependency('libpng', fallback: ['libpng', 'libpng_dep'])
-pugixml_dep = dependency('pugixml', fallback: ['pugixml', 'pugixml_dep'])
-zlib_dep = dependency('zlib', fallback: ['zlib', 'zlib_dep'])
+libpng_dep = dependency('libpng', fallback: ['libpng', 'libpng_dep'], static: get_option('portable'))
+pugixml_dep = dependency('pugixml', fallback: ['pugixml', 'pugixml_dep'], static: get_option('portable'))
+zlib_dep = dependency('zlib', fallback: ['zlib', 'zlib_dep'], static: get_option('portable'))
 
 # These deps are vendored in our source code; we manually add meson.build files
 # to build them as static libraries, see the subfolders for these libraries
 # under the source folder.
-liblcf_dep = dependency('liblcf', fallback: ['liblcf', 'liblcf_dep'])
-libtga_dep = dependency('libtga', fallback: ['libtga', 'libtga_dep'])
+liblcf_dep = dependency('liblcf', fallback: ['liblcf', 'liblcf_dep'], static: get_option('portable'))
+libtga_dep = dependency('libtga', fallback: ['libtga', 'libtga_dep'], static: get_option('portable'))
 
-sdl2_dep = dependency('sdl2')
-sdl2_ttf_dep = dependency('SDL2_ttf')
-sdl2_image_dep = dependency('SDL2_image')
+sdl2_dep = dependency('sdl2', static: get_option('portable'))
+sdl2_ttf_dep = dependency('SDL2_ttf', static: get_option('portable'))
+sdl2_image_dep = dependency('SDL2_image', static: get_option('portable'))
 
 dependencies = [
   thread_dep,

--- a/freesprite/meson.build
+++ b/freesprite/meson.build
@@ -24,9 +24,9 @@ zlib_dep = dependency('zlib', fallback: ['zlib', 'zlib_dep'], static: get_option
 liblcf_dep = dependency('liblcf', fallback: ['liblcf', 'liblcf_dep'], static: get_option('portable'))
 libtga_dep = dependency('libtga', fallback: ['libtga', 'libtga_dep'], static: get_option('portable'))
 
-sdl2_dep = dependency('sdl2', static: get_option('portable'), fallback: ['sdl2', 'sdl2_dep'])
-sdl2_ttf_dep = dependency('SDL2_ttf', fallback: ['sdl2_ttf', 'sdl2_ttf_dep'], static: get_option('portable'))
-sdl2_image_dep = dependency('SDL2_image', fallback: ['sdl2_image', 'sdl2_image_dep'], static: get_option('portable'))
+sdl2_dep = dependency('sdl2', fallback: ['sdl2', 'sdl2_dep'])
+sdl2_ttf_dep = dependency('SDL2_ttf', fallback: ['sdl2_ttf', 'sdl2_ttf_dep'])
+sdl2_image_dep = dependency('SDL2_image', fallback: ['sdl2_image', 'sdl2_image_dep'])
 
 dependencies = [
   thread_dep,
@@ -42,7 +42,7 @@ dependencies = [
 
 # Windows requires sdl2main dependency
 if host_machine.system() == 'windows'
-  sdl2main_dep = dependency('sdl2main', fallback: ['sdl2main', 'sdl2main_dep'], static: get_option('portable'))
+  sdl2main_dep = dependency('sdl2main', fallback: ['sdl2main', 'sdl2main_dep'])
   dependencies += sdl2main_dep
 endif
 

--- a/freesprite/meson.build
+++ b/freesprite/meson.build
@@ -24,9 +24,9 @@ zlib_dep = dependency('zlib', fallback: ['zlib', 'zlib_dep'], static: get_option
 liblcf_dep = dependency('liblcf', fallback: ['liblcf', 'liblcf_dep'], static: get_option('portable'))
 libtga_dep = dependency('libtga', fallback: ['libtga', 'libtga_dep'], static: get_option('portable'))
 
-sdl2_dep = dependency('sdl2', static: get_option('portable'))
-sdl2_ttf_dep = dependency('SDL2_ttf', static: get_option('portable'))
-sdl2_image_dep = dependency('SDL2_image', static: get_option('portable'))
+sdl2_dep = dependency('sdl2', static: get_option('portable'), fallback: ['sdl2', 'sdl2_dep'])
+sdl2_ttf_dep = dependency('SDL2_ttf', fallback: ['sdl2_ttf', 'sdl2_ttf_dep'], static: get_option('portable'))
+sdl2_image_dep = dependency('SDL2_image', fallback: ['sdl2_image', 'sdl2_image_dep'], static: get_option('portable'))
 
 dependencies = [
   thread_dep,
@@ -42,7 +42,7 @@ dependencies = [
 
 # Windows requires sdl2main dependency
 if host_machine.system() == 'windows'
-  sdl2main_dep = dependency('sdl2main')
+  sdl2main_dep = dependency('sdl2main', fallback: ['sdl2main', 'sdl2main_dep'], static: get_option('portable'))
   dependencies += sdl2main_dep
 endif
 

--- a/linux_build.sh
+++ b/linux_build.sh
@@ -8,7 +8,7 @@ _prefix="${PWD}/target/debug"
 portable=false
 buildtype=debug
 keep=false
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
 	case $1 in
 		"--no-setup") no_setup=1; shift;;
 		"--run") run=1; shift;;
@@ -23,7 +23,7 @@ done
 prefix="${prefix:-${_prefix}}"
 
 if [ ! -e "freesprite" ]; then echo "Not in source directory"; exit 1; fi
-if [ "$keep" == "false" ]; then if [ -e "$prefix" ]; then rm -r "$prefix"; fi; fi
+if [ "$keep" = "false" ]; then if [ -e "$prefix" ]; then rm -r "$prefix"; fi; fi
 
 set -e
 if [ "$no_setup" != "1" ] || [ ! -e 'build' ]; then

--- a/subprojects/sdl2.wrap
+++ b/subprojects/sdl2.wrap
@@ -1,0 +1,15 @@
+[wrap-file]
+directory = SDL2-2.30.6
+source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.30.6/SDL2-2.30.6.tar.gz
+source_filename = SDL2-2.30.6.tar.gz
+source_hash = c6ef64ca18a19d13df6eb22df9aff19fb0db65610a74cc81dae33a82235cacd4
+patch_filename = sdl2_2.30.6-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.30.6-2/get_patch
+patch_hash = aa9f6a4947b07510c2ea84fb457e965bebe5a5deeb9f5059fbcf10dfe6b76d1f
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_2.30.6-2/SDL2-2.30.6.tar.gz
+wrapdb_version = 2.30.6-2
+
+[provide]
+sdl2 = sdl2_dep
+sdl2main = sdl2main_dep
+sdl2_test = sdl2_test_dep

--- a/subprojects/sdl2_image.wrap
+++ b/subprojects/sdl2_image.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = SDL2_image-2.6.3
+source_url = https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.6.3.tar.gz
+source_filename = SDL2_image-2.6.3.tar.gz
+source_hash = 931c9be5bf1d7c8fae9b7dc157828b7eee874e23c7f24b44ba7eff6b4836312c
+patch_filename = sdl2_image_2.6.3-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_image_2.6.3-2/get_patch
+patch_hash = 1741274f30b5b88299b2588a498a54a4203861ec1fa64c3bf99b359a6b618354
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_image_2.6.3-2/SDL2_image-2.6.3.tar.gz
+wrapdb_version = 2.6.3-2
+
+[provide]
+sdl2_image = sdl2_image_dep

--- a/subprojects/sdl2_ttf.wrap
+++ b/subprojects/sdl2_ttf.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = SDL2_ttf-2.20.1
+source_url = https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.20.1.tar.gz
+source_filename = SDL2_ttf-2.20.1.tar.gz
+source_hash = 78cdad51f3cc3ada6932b1bb6e914b33798ab970a1e817763f22ddbfd97d0c57
+patch_filename = sdl2_ttf_2.20.1-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_ttf_2.20.1-2/get_patch
+patch_hash = ab9825e6a09ca625db799be312c1a1e1177bbb576e832229e88c5db0d486e2b3
+wrapdb_version = 2.20.1-2
+
+[provide]
+sdl2_ttf = sdl2_ttf_dep


### PR DESCRIPTION
should hopefully fix the ci portable build linking against pugixml .so