### PR TITLE
flatpak: add --device=dri to flatpak args

### DIFF
--- a/freesprite/linux/flatpak/com.github.counter185.voidsprite.yml
+++ b/freesprite/linux/flatpak/com.github.counter185.voidsprite.yml
@@ -16,6 +16,7 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --filesystem=host
+  - --device=dri
 
 cleanup:
   - /include


### PR DESCRIPTION
should hopefully fix voidsprite not launching on some systems